### PR TITLE
Fully reworked the indentation and formatting logic for the clipboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,16 +75,34 @@ This project is built in **Angular**, enhanced by **Prism.js** for syntax highli
 - **`syntax-highlight.service.ts`**
   The **heart of the application**, responsible for turning raw code into a highlighted snippet and allowing for a properly formatted clipboard copy. It offers two primary methods:
 
-  1. **`highlightCode(code: string, language: LanguageDefinition)`**
-     - Loads the right Prism.js file if necessary.
-     - Applies syntax highlighting and returns the resulting HTML.
+  1. **`highlightCode(code: string, language: LanguageDefinition): Promise<string>`**
+
+     - Sanitizes input (e.g., replaces unsupported characters).
+     - Dynamically loads Prism.js language definitions if needed.
+     - Returns HTML with syntax-highlighted code using Prism.
 
   2. **`copyToClipboard()`**
-     - Wraps every text node in `<span>` elements so inline styles can be accurately transferred.
-     - Converts leading spaces/tabs into placeholder markers, ensuring consistent indentation after copying.
-     - Applies minimal inline CSS by reading and setting only the essential style properties needed (e.g., color, font size).
-     - Replaces the placeholder markers with the desired indentation characters (tabs, multiple spaces, or non-breaking spaces).
-     - Copies two versions to the clipboard—an `text/html` snippet (with inline styling) and a simpler `text/plain` version—making sure the syntax colors and indentation remain intact in various editors (Word, PowerPoint, etc.).
+
+     - Locates the highlighted `<pre><code>` block in the DOM.
+     - Clones and processes the node structure to preserve:
+       - Inline formatting (e.g., font styles, colors).
+       - Line breaks and indentation (tabs or spaces).
+     - Converts structure into `<p>` and `<span>` blocks for rich formatting.
+     - Outputs two clipboard formats:
+       - `text/html`: Styled for pasting into Word, PowerPoint, etc.
+       - `text/plain`: Clean text with accurate indentation.
+
+#### Utils
+
+- **IndentationFormatter** – Masks and unmasks indentation
+- **InlineStyleApplier** – Captures and reapplies essential font-related styles for inline use.
+- **LinesCollector** – Transforms the DOM structure into styled line-by-line paragraphs, while:
+  - Masking leading whitespace,
+  - Rebuilding indentation with accurate styling (via `IndentationFormatter`),
+  - Ensuring Office-friendly formatting (via `OfficeUtils`).
+- **NodeUtils** - Reusable utility methods such as generating DOM nodes, add attributes, etc.
+- **OfficeUtils** - Utility methods for proper office formatting (i.e., for adding mso-spacerun:yes to preserve whitespaces)
+- **Sanitizer** - Sanitizes input and output strings to replace invalid characters
 
 # Contributing & Local Installation
 

--- a/src/app/constants/const.ts
+++ b/src/app/constants/const.ts
@@ -38,5 +38,4 @@ export const HTML_CODE_SELECTOR = "code.highlighted-code";
 export const INDENTATION_MODE_MAP = {
   Spaces: "spaces",
   Tabs: "tabs",
-  NBSP: "nbsp",
 } as const;

--- a/src/app/constants/sanitization-maps.ts
+++ b/src/app/constants/sanitization-maps.ts
@@ -23,6 +23,6 @@ export const INPUT_SANITIZE_MAP: Partial<Record<SpecialCharacters, SpecialCharac
  * This is primarily used for converting characters like newline into appropriate display formats.
  */
 export const OUTPUT_SANITIZE_MAP: Partial<Record<SpecialCharacters, SpecialCharacters>> = {
-  [SpecialCharacters.NEWLINE]: SpecialCharacters.LINE_BREAK, // Newline -> <br>
+  // [SpecialCharacters.NEWLINE]: SpecialCharacters.LINE_BREAK, // Newline -> <br>
   // Add more output replacements as needed
 };

--- a/src/app/constants/special-characters.ts
+++ b/src/app/constants/special-characters.ts
@@ -2,6 +2,8 @@
 export enum SpecialCharacters {
   MARKER = "\u001F",
   SPAN_TAG = "span",
+  PARAGRAPH_TAG = "p",
+  STYLE_TAG = "style",
   VERTICAL_TAB = "\u000b",
   TAB = "\t",
   NEWLINE = "\n",

--- a/src/app/regex/regex-patterns.ts
+++ b/src/app/regex/regex-patterns.ts
@@ -44,4 +44,14 @@ export class RegexPatterns {
    * Matches lines that contain only whitespace or are empty at the beginning or end of a string.
    */
   public static BLANK_LINES_REGEX = new RegExp(/^\s*\n+|\n+\s*$/g, RegexFlags.GLOBAL);
+
+  /**
+   * Regular expression to match both Windows (\r\n) and Unix (\n) style newlines.
+   */
+  public static NEWLINE_REGEX = new RegExp(/\r?\n/, RegexFlags.GLOBAL);
+
+  /**
+   * Regular expression to match one or more marker characters at the beginning of a string.
+   */
+  public static MARKER_ONLY_REGEX = new RegExp(`^${SpecialCharacters.MARKER}+`);
 }

--- a/src/app/utils/inline-style-applier.ts
+++ b/src/app/utils/inline-style-applier.ts
@@ -1,16 +1,12 @@
-import { NodeUtils } from "@utils/node-utils";
 import { StyleProperties } from "@types";
 import { getEntries } from "@utils/utils";
 
 /**
- * This class is necessary because when copying HTML to the clipboard, styles must be applied as inline styles manually.
- * Otherwise, they won't have any effect. This process is not done automatically due to performance reasons — assigning all
- * inline styles to all elements would create a significant overhead. Instead, we manually apply only the essential styles,
- * primarily font-related ones such as font-family and color, while stripping away all others.
+ * Applies essential inline styles to HTML elements for clipboard copying.
  *
- * Additionally, since some text nodes have been converted into span nodes (which would typically inherit properties from
- * their parent), we store the root styles (i.e., styles of the root element) and apply them to these converted text nodes.
- * This ensures that text appearance remains consistent even after transformation.
+ * Since stylesheets aren't preserved in clipboard content, only key font-related
+ * styles are manually inlined (e.g., font-family, color). Layout and background styles
+ * are excluded to keep the copied HTML lightweight and readable.
  */
 export class InlineStyleApplier {
   /**
@@ -23,7 +19,8 @@ export class InlineStyleApplier {
   private static rootStyleProperties: StyleProperties = {};
 
   /**
-   * Defines the subset of styles that are copied inline when creating the final snippet. We can also provide default values for which inline styles do not get applied for (i.e., the default font style is "normal" and we don't have to repeat that for every single element)
+   * Defines the subset of styles that are copied inline when creating the final snippet.
+   * We can also provide default values for which inline styles do not get applied for (i.e., the default font style is "normal" and we don't have to repeat that for every single element)
    *
    * Mostly font-related properties are retained, while background colors, margins, paddings,
    * and other layout styles are excluded. This keeps the copied content lightweight while
@@ -39,32 +36,19 @@ export class InlineStyleApplier {
   };
 
   /**
-   * Recursively applies minimal inline font styling (color, font-size, etc.) from the original node to the cloned node.
-   *
-   *  - Only properties specified in `RELEVANT_STYLE_PROPERTIES` are considered to avoid unnecessary inline styles.
-   *  - If the node is the root, its computed styles are stored for application to child nodes that require them.
-   *  - Converted text nodes (now span elements) are styled explicitly to maintain visual consistency.
-   *
-   * @param original - The original DOM node to extract computed styles from.
-   * @param cloned - The cloned DOM node to apply styles to.
-   * @param [isRoot=false] - Indicates if this is the top-level call (used to store root styles).
+   * Extracts and stores root-level styles to apply to converted text elements.
    */
-  static applyMinimalInlineStyles(original: Node, cloned: Node, isRoot = false): void {
-    if (isRoot) {
-      // Reset root-level styles before processing
-      this.rootStyleProperties = {};
-    }
+  public static captureRootStyles(element: HTMLElement): void {
+    // Retrieve computed style for the original element
+    const computedStyle: CSSStyleDeclaration = window.getComputedStyle(element);
 
-    if (NodeUtils.isHtmlElement(original) && NodeUtils.isHtmlElement(cloned)) {
-      this.applyElementStyles(original, cloned, isRoot);
-    } else if (NodeUtils.isHtmlElement(cloned) && !isRoot) {
-      this.applyStoredRootStyles(cloned);
-    }
+    // Apply only relevant styles
+    getEntries(this.RELEVANT_STYLE_PROPERTIES).forEach(([propKey, defaultValue]) => {
+      const value: string = computedStyle.getPropertyValue(propKey);
 
-    // Recursively apply styles to child nodes
-    cloned.childNodes.forEach((child: ChildNode, index: number): void => {
-      if (NodeUtils.isHtmlElement(child)) {
-        this.applyMinimalInlineStyles(original.childNodes[index], child);
+      if (value !== defaultValue) {
+        // Store root-level styles for later use in child elements
+        this.rootStyleProperties[propKey] = value;
       }
     });
   }
@@ -72,18 +56,10 @@ export class InlineStyleApplier {
   /**
    * Extracts and applies computed styles from the original element to the cloned element.
    *
-   * - All class attributes are removed since they won't be included in the copied snippet.
-   * - Only relevant styles (font and text-related) are applied as inline styles.
-   * - If the element is the root, its styles are stored for application to converted text nodes.
-   *
    * @param original - The original HTML element from which styles are extracted.
    * @param cloned - The cloned HTML element to which styles will be applied.
-   * @param isRoot - Boolean indicating if this element is the root.
    */
-  private static applyElementStyles(original: HTMLElement, cloned: HTMLElement, isRoot: boolean): void {
-    // Remove classes as they are useless (because only inline styles are copied to clipboard, no stylesheets)
-    cloned.removeAttribute("class");
-
+  public static applyElementStyles(original: HTMLElement, cloned: HTMLElement): void {
     // Retrieve computed style for the original element
     const computedStyle: CSSStyleDeclaration = window.getComputedStyle(original);
 
@@ -91,13 +67,8 @@ export class InlineStyleApplier {
     getEntries(this.RELEVANT_STYLE_PROPERTIES).forEach(([propKey, defaultValue]) => {
       const value: string = computedStyle.getPropertyValue(propKey);
 
-      if (isRoot) {
-        // Store root-level styles for later use in child elements
-        this.rootStyleProperties[propKey] = value;
-      }
-
       // Apply style only if it's different from the default
-      if (value && value !== String(defaultValue)) {
+      if (value && value !== defaultValue) {
         cloned.style.setProperty(propKey, value);
       }
     });
@@ -112,7 +83,7 @@ export class InlineStyleApplier {
    *
    * @param element - The HTML element to which stored root styles will be applied.
    */
-  private static applyStoredRootStyles(element: HTMLElement): void {
+  public static applyStoredRootStyles(element: HTMLElement): void {
     // Apply stored root properties to non-root elements that require explicit styling
     getEntries(this.rootStyleProperties).forEach(([propKey, propValue]) => {
       if (propValue && propValue !== this.RELEVANT_STYLE_PROPERTIES[propKey]) {

--- a/src/app/utils/line-collector.ts
+++ b/src/app/utils/line-collector.ts
@@ -1,0 +1,260 @@
+import { NodeUtils } from "@utils/node-utils";
+import { InlineStyleApplier } from "@utils/inline-style-applier";
+import { INDENTATION_MODE_MAP } from "../constants";
+import { IndentationModeValue } from "@types";
+import { IndentationFormatter } from "@utils/indentation-formatter";
+import { RegexPatterns } from "../regex/regex-patterns";
+import { OfficeUtils } from "@utils/office-utils";
+
+/**
+ * A utility class that:
+ *  1. Recursively processes an original node and its cloned counterpart,
+ *  2. Collects text and element nodes line-by-line (using detected newlines),
+ *  3. Appends them as paragraph elements (`<p>`) to a target parent node.
+ *
+ * This preserves the structure of lines, applying indentation (spaces/tabs)
+ * while removing unnecessary attributes from cloned nodes.
+ */
+export class LinesProcessor {
+  private readonly lines: Node[][]; // Stores arrays of Node objects, each representing a single line
+  private readonly tabSize: number; // Number of spaces to use in place of a single tab
+  private readonly indentationMode: IndentationModeValue; // Whether we want to use spaces or tabs for indentation
+  private isStartOfLine: boolean; // Tracks if we are at the start of a line
+  private maxIndentationMarkers = 0; // Tracks the maximum number of consecutive markers in any line
+
+  /**
+   * @param indentationMode Desired indentation mode (Tabs vs Spaces).
+   * @param tabSize Number of spaces used when replacing tab characters or converting marker runs.
+   */
+  constructor(indentationMode: IndentationModeValue, tabSize: number) {
+    this.lines = [[]];
+    this.isStartOfLine = true;
+    this.tabSize = tabSize;
+    this.indentationMode = indentationMode;
+  }
+
+  /**
+   * Recursively processes `original` and `cloned` nodes in parallel, collecting content
+   * into a line buffer. Rebuilds the cloned node by appending paragraphs for each line.
+   *
+   * @param original The original Node.
+   * @param cloned   The cloned Node (will have children removed and replaced by line-based paragraphs).
+   */
+  public collectLinesFromNodes(original: Node, cloned: Node): void {
+    if (NodeUtils.isHtmlElement(cloned)) {
+      NodeUtils.removeAllAttributesExceptStyle(cloned);
+    }
+
+    // Capture root styles from the original, to apply those to newly created spans/paragraphs later
+    InlineStyleApplier.captureRootStyles(original as HTMLElement);
+
+    const originalChildren = Array.from(original.childNodes);
+    const clonedChildren = Array.from(cloned.childNodes);
+
+    originalChildren.forEach((child, index) => {
+      this.processNode(child, clonedChildren[index]);
+    });
+
+    // Clear any existing content in the cloned node
+    NodeUtils.removeChildren(cloned);
+
+    // Rebuild the cloned node by appending lines as <p> elements
+    this.appendCollectedLinesAsParagraphs(cloned);
+  }
+
+  /**
+   * Appends each collected line as a `<p>` element to the provided parent node.
+   * If using tabs, also inserts custom styles for tab stops based on the maximum marker count.
+   *
+   * @param parent The parent node to receive the appended `<p>` elements.
+   */
+  public appendCollectedLinesAsParagraphs(parent: Node): void {
+    for (const lineNodes of this.lines) {
+      const p: HTMLParagraphElement = NodeUtils.createParagraph();
+      InlineStyleApplier.applyStoredRootStyles(p);
+      // Remove line spacing (margins)
+      OfficeUtils.applyNoMarginStyle(p);
+
+      // If there's nothing in this line, we still append an empty paragraph
+      if (lineNodes.length === 0) {
+        p.appendChild(OfficeUtils.createEmptyLineSpan());
+        parent.appendChild(p);
+        continue;
+      }
+
+      // Append each collected node
+      lineNodes.forEach((node) => p.appendChild(node));
+
+      // When using tabs, set up tab stops according to the maximum marker count
+      if (this.indentationMode === INDENTATION_MODE_MAP.Tabs) {
+        const requiredStops = Math.ceil(this.maxIndentationMarkers / this.tabSize);
+        const newStyle = NodeUtils.getTabStops(requiredStops);
+        NodeUtils.appendInlineStyle(p, newStyle);
+      }
+
+      parent.appendChild(p);
+    }
+  }
+
+  /**
+   * Inspects the node's type and routes it to the appropriate handler.
+   *
+   * @param originalNode The node in the original DOM.
+   * @param clonedNode   The corresponding node in the cloned DOM.
+   */
+  private processNode(originalNode: Node, clonedNode: Node): void {
+    if (NodeUtils.isHtmlElement(originalNode) && NodeUtils.isHtmlElement(clonedNode)) {
+      this.handleElement(originalNode as HTMLElement, clonedNode as HTMLElement);
+      return;
+    }
+
+    if (NodeUtils.isTextNode(clonedNode)) {
+      this.handleTextNode(originalNode, clonedNode);
+      return;
+    }
+
+    // Other node types (comments, etc.) are currently ignored/unchanged
+  }
+
+  /**
+   * Copies inline styles to the cloned element, then iterates through child nodes
+   * and processes them. Spans are inlined directly onto the current line;
+   * other elements are traversed recursively.
+   *
+   * @param originalNode The original HTML element.
+   * @param clonedNode   The cloned HTML element.
+   */
+  private handleElement(originalNode: HTMLElement, clonedNode: HTMLElement): void {
+    // Copy inline styles from original to cloned
+    InlineStyleApplier.applyElementStyles(originalNode, clonedNode);
+    // Remove all attributes except style
+    NodeUtils.removeAllAttributesExceptStyle(clonedNode);
+
+    const origChildren = Array.from(originalNode.childNodes);
+    const clonedChildren = Array.from(clonedNode.childNodes);
+
+    // Always recurse through each child, letting handleTextNode() split newlines
+    origChildren.forEach((child, index) => {
+      this.processNode(child, clonedChildren[index]);
+    });
+  }
+
+  /**
+   * Splits text content by newline, starting a new line each time a newline is encountered.
+   * Leading indentation markers are handled at the beginning of each line.
+   *
+   * @param originalNode
+   * @param clonedNode The text node in the cloned DOM.
+   */
+  private handleTextNode(originalNode: Node, clonedNode: Node): void {
+    const textContent = clonedNode.textContent || "";
+    const segments = textContent.split(RegexPatterns.NEWLINE_REGEX);
+
+    segments.forEach((segment, index) => {
+      if (index > 0) {
+        // Encountered a newline => finalize the previous line, start a new line
+        this.startNewLine();
+      }
+
+      if (segment.length > 0) {
+        let chunk = segment;
+        if (this.isStartOfLine) {
+          // Mask out indentation markers only at the very start of a line
+          chunk = IndentationFormatter.maskIndentation(chunk, this.tabSize);
+        }
+
+        this.createSpanFromChunk(chunk, originalNode.parentElement);
+        this.isStartOfLine = false;
+      }
+    });
+  }
+
+  /**
+   * Creates one or more `<span>` elements from a text chunk. If the chunk starts
+   * with indentation markers, it creates a span for that portion and (optionally) a
+   * second span for the remainder. Otherwise, it creates a single text span.
+   *
+   * @param chunk The piece of text to convert into span(s).
+   * @param parent
+   */
+  private createSpanFromChunk(chunk: string, parent: HTMLElement | null): void {
+    // Match a run of indentation markers at the start of the chunk
+    const markerMatch = chunk.match(RegexPatterns.MARKER_ONLY_REGEX);
+
+    if (markerMatch) {
+      const matchedMarkers = markerMatch[0];
+      const markerLength = matchedMarkers.length;
+
+      if (markerLength === chunk.length) {
+        // The entire chunk is just markers
+        this.getCurrentLine().push(this.createMarkerSpan(chunk));
+      } else {
+        // Part markers, part normal text
+        const markerSpan = this.createMarkerSpan(matchedMarkers);
+        const textSpan = NodeUtils.createSpanWithTextContent(chunk.slice(markerLength));
+        this.applyParentSpanStyles(parent, textSpan);
+        this.getCurrentLine().push(markerSpan, textSpan);
+      }
+    } else {
+      // No leading markers => just normal text
+      const textSpan = NodeUtils.createSpanWithTextContent(chunk);
+      this.applyParentSpanStyles(parent, textSpan);
+      this.getCurrentLine().push(textSpan);
+    }
+  }
+
+  /**
+   * Creates a `<span>` dedicated to indentation markers, applying styles based on the
+   * configured `mode` (tabs vs. spaces). Updates `maxMarkers` as needed.
+   *
+   * @param markerText The string of marker characters to convert.
+   * @returns A span containing the transformed text (or empty if tab-based).
+   */
+  private createMarkerSpan(markerText: string): HTMLElement {
+    const markerSpan = NodeUtils.createSpanWithTextContent(markerText);
+    const markerCount = markerText.length;
+
+    // Update the max marker count for final tab stops
+    this.maxIndentationMarkers = Math.max(this.maxIndentationMarkers, markerCount);
+
+    if (this.indentationMode === INDENTATION_MODE_MAP.Tabs) {
+      // Replace the markers with tabs (not needed for Office-Applications, but might be for others)
+      markerSpan.textContent = IndentationFormatter.unmaskIndentationWithTabs(markerText, this.tabSize);
+      const tabCount = Math.floor(markerCount / this.tabSize);
+      // MS Office syntax required to properly indent the line with a number of tabs
+      OfficeUtils.applyTabSpacing(markerSpan, tabCount);
+    } else {
+      // Convert marker characters to actual spaces
+      markerSpan.textContent = IndentationFormatter.unmaskIndentationWithNbsp(markerText);
+      // MS Office syntax required to keep multiple leading spaces
+      OfficeUtils.preserveWhiteSpace(markerSpan);
+    }
+
+    return markerSpan;
+  }
+
+  /**
+   * Applies the parent's inline styles to the child span ONLY if the parent is a <span>.
+   */
+  private applyParentSpanStyles(parent: HTMLElement | null, childSpan: HTMLElement): void {
+    if (NodeUtils.isSpan(parent)) {
+      InlineStyleApplier.applyElementStyles(parent, childSpan);
+    }
+  }
+
+  /**
+   * Signals the start of a new line by pushing a fresh array onto `allLines`.
+   * Also resets `isStartOfLine` to `true`.
+   */
+  private startNewLine(): void {
+    this.lines.push([]);
+    this.isStartOfLine = true;
+  }
+
+  /**
+   * @returns The array of nodes that make up the current (most recent) line.
+   */
+  private getCurrentLine(): Node[] {
+    return this.lines[this.lines.length - 1];
+  }
+}

--- a/src/app/utils/node-utils.ts
+++ b/src/app/utils/node-utils.ts
@@ -1,51 +1,114 @@
 import { SpecialCharacters } from "../constants";
 
-/**
- * Utility class for processing DOM nodes.
- */
 export class NodeUtils {
+  private static readonly CM_IN_PTS: number = 28.3465;
+
   /**
-   * Recursively traverses a node's children and wraps text nodes inside `<span>` elements.
-   * This ensures that all standalone text content is enclosed within a span for styling or manipulation.
+   * Generates a CSS string with tab stop positions for tab-indented content.
    *
-   * @param node - The parent node whose child nodes will be processed.
+   * @param count Number of tab stops to create.
+   * @returns A CSS string defining left tab stops.
    */
-  public static wrapAllTextNodesWithSpan(node: Node): void {
-    node.childNodes.forEach((child: ChildNode): void => {
-      // If the child is a non-empty text node and is not already inside a span
-      if (this.isTextNode(child) && !this.isInsideSpan(child) && child.nodeValue?.trim() !== "") {
-        // Create a new `<span>` element to wrap the text node
-        const span: HTMLSpanElement = document.createElement(SpecialCharacters.SPAN_TAG);
-        // Set the span's text content to match the original text node
-        span.textContent = child.nodeValue;
-        // Replace the text node with the new `<span>` element
-        node.replaceChild(span, child);
-      } else if (this.isHtmlElement(child)) {
-        // If the child is an HTML element, recursively process its child nodes
-        this.wrapAllTextNodesWithSpan(child);
-      }
-    });
+  public static getTabStops(count: number): string {
+    if (count === 0) return "";
+    const stops = Array.from({ length: count }, (_, i) => `left ${(i + 1) * this.CM_IN_PTS}pt`).join(" ");
+    return `tab-stops: ${stops};`;
   }
 
-  /** Determines if the given node is an HTMLElement. */
+  /**
+   * Appends a new inline style to an existing element's style attribute.
+   *
+   * @param element The HTML element to modify.
+   * @param style A CSS string to append.
+   */
+  public static appendInlineStyle(element: HTMLElement, style: string) {
+    const existingStyle = element.getAttribute(SpecialCharacters.STYLE_TAG) || "";
+    const combinedStyle = `${existingStyle.trim()}${existingStyle.trim().endsWith(";") || !existingStyle.trim() ? "" : ";"}${style}`;
+    element.setAttribute(SpecialCharacters.STYLE_TAG, combinedStyle);
+  }
+
+  /**
+   * Removes all attributes from an element except for 'style'.
+   *
+   * @param element The HTML element to clean.
+   */
+  public static removeAllAttributesExceptStyle(element: HTMLElement): void {
+    // Loop backwards to avoid index shifting
+    for (let i = element.attributes.length - 1; i >= 0; i--) {
+      const attrName = element.attributes[i].name;
+      if (attrName !== SpecialCharacters.STYLE_TAG) {
+        element.removeAttribute(attrName);
+      }
+    }
+  }
+  /**
+   * Removes all child nodes from the given parent node.
+   *
+   * @param parent The node to clear.
+   */
+  public static removeChildren(parent: Node): void {
+    while (parent.firstChild) {
+      parent.removeChild(parent.firstChild);
+    }
+  }
+
+  /**
+   * Creates a <span> element with the given text content.
+   *
+   * @param textContent The text to insert.
+   * @returns A <span> element containing the text.
+   */
+  public static createSpanWithTextContent(textContent: string): HTMLSpanElement {
+    const span = this.createSpan();
+    span.textContent = textContent;
+    return span;
+  }
+
+  /**
+   * Creates an empty <span> element.
+   *
+   * @returns A new <span> element.
+   */
+  public static createSpan(): HTMLSpanElement {
+    return document.createElement(SpecialCharacters.SPAN_TAG);
+  }
+
+  /**
+   * Creates an empty <p> element.
+   *
+   * @returns A new <p> element.
+   */
+  public static createParagraph(): HTMLParagraphElement {
+    return document.createElement(SpecialCharacters.PARAGRAPH_TAG);
+  }
+
+  /**
+   * Checks if a node is an HTMLElement.
+   *
+   * @param node The node to check.
+   * @returns True if the node is an HTMLElement.
+   */
   public static isHtmlElement(node?: Node | null): node is HTMLElement {
     return !!node && node.nodeType === Node.ELEMENT_NODE;
   }
 
-  /** Determines if the given node is a Text node. */
+  /**
+   * Checks if a node is a Text node.
+   *
+   * @param node The node to check.
+   * @returns True if the node is a Text node.
+   */
   public static isTextNode(node?: Node | null): node is Text {
     return !!node && node.nodeType === Node.TEXT_NODE;
   }
 
-  /** Checks if the given node is inside a `<span>`. */
-  public static isInsideSpan(node: Node): boolean {
-    let parent: ParentNode | null = node.parentNode;
-    while (parent) {
-      if (parent.nodeName.toLowerCase() === SpecialCharacters.SPAN_TAG) {
-        return true;
-      }
-      parent = parent.parentNode;
-    }
-    return false;
+  /**
+   * Checks if a node is a <span> element.
+   *
+   * @param node The node to check.
+   * @returns True if the node is a <span> element.
+   */
+  public static isSpan(node?: Node | null): node is HTMLSpanElement {
+    return !!node && node.nodeType === Node.ELEMENT_NODE && node.nodeName.toLowerCase() === SpecialCharacters.SPAN_TAG;
   }
 }

--- a/src/app/utils/office-utils.ts
+++ b/src/app/utils/office-utils.ts
@@ -1,0 +1,48 @@
+import { NodeUtils } from "@utils/node-utils";
+import { SpecialCharacters } from "../constants";
+
+/**
+ * Utility class for applying inline styles required for proper formatting
+ * when content is pasted into Microsoft Office applications (e.g., Word, Outlook).
+ * These styles ensure spacing, margins, and tabbing behave as expected in Office environments.
+ */
+export class OfficeUtils {
+  /**
+   * Creates a `<span>` element containing a non-breaking space, with styles
+   * that ensure it is preserved when rendered in Microsoft Office applications.
+   * This is used to represent an intentionally empty line that Office
+   * would otherwise strip out.
+   *
+   * @returns A styled `<span>` element representing an empty line.
+   */
+  public static createEmptyLineSpan(): HTMLSpanElement {
+    const span: HTMLSpanElement = NodeUtils.createSpanWithTextContent(SpecialCharacters.NON_BREAKING_SPACE);
+    this.preserveWhiteSpace(span); // This ensures Office apps don't strip it away
+    return span;
+  }
+
+  /**
+   * Removes all margins from the given HTML element by applying inline CSS.
+   * @param element - The HTML element to modify.
+   */
+  public static applyNoMarginStyle(element: HTMLElement): void {
+    NodeUtils.appendInlineStyle(element, "margin:0cm;");
+  }
+
+  /**
+   * Ensures that white spaces are preserved in the element's style.
+   * @param element - The HTML element to modify.
+   */
+  public static preserveWhiteSpace(element: HTMLElement): void {
+    NodeUtils.appendInlineStyle(element, "mso-spacerun:yes");
+  }
+
+  /**
+   * Applies a tab count to the given element using Microsoft Office-specific styling.
+   * @param element - The HTML element to modify.
+   * @param tabCount - The number of tabs to apply.
+   */
+  public static applyTabSpacing(element: HTMLElement, tabCount: number): void {
+    NodeUtils.appendInlineStyle(element, `mso-tab-count:${tabCount}`);
+  }
+}


### PR DESCRIPTION
Fully reworked the logic on how the indentation and formatting gets executed when copying stuff to the clipboard. This mostly boils down to some Office-related tags such as `mso-spacerun:yes` to preserve whitespaces, some improvements and only one single pass over the code (instead of many as it was done before). This also solves #26 as there are no special characters involved anymore that do not get replaced.