### PR TITLE
fix: Fixes the source tab indentation when pasting code

### DIFF
--- a/src/app/regex/regex-patterns.ts
+++ b/src/app/regex/regex-patterns.ts
@@ -38,7 +38,7 @@ export class RegexPatterns {
    * Regular expression to match any non-ASCII character.
    * Matches characters outside the printable ASCII range (0x20 to 0x7E), excluding newline characters.
    */
-  public static NON_ASCII_CHARACTERS_REGEX = new RegExp(/[^\x20-\x7E\n]/g, RegexFlags.GLOBAL);
+  public static NON_ASCII_CHARACTERS_REGEX = new RegExp(/[^\x20-\x7E\n\u00A0\t]/g, RegexFlags.GLOBAL);
   /**
    * Regular expression to match blank lines.
    * Matches lines that contain only whitespace or are empty at the beginning or end of a string.


### PR DESCRIPTION
When pasting in code with leading tabs as indentation, it currently breaks because all non-ascii characters get removed. This hotfix defines exceptions for spaces and tabs.